### PR TITLE
Batch mode does not work

### DIFF
--- a/pkg_replace.sh
+++ b/pkg_replace.sh
@@ -761,7 +761,7 @@ create_tmpdir() {
 clean_tmpdir() {
 	if ! isempty ${tmpdir}; then
 		try rmdir "${tmpdir}" ||
-			warn "Couldn't remove the working direcotry: ${tmpdir}"
+			warn "Couldn't remove the working directory: ${tmpdir}"
 		tmpdir=
 	fi
 }
@@ -1700,7 +1700,7 @@ do_replace() {
 	clean_libs ||
 		warn "Failed to remove the preserved shared libraries."
 	remove_dir "${pkg_tmpdir}" ||
-		warn "Couldn't remove the working direcotry."
+		warn "Couldn't remove the working directory."
 
 	case ${result} in
 	done)

--- a/pkg_replace.sh
+++ b/pkg_replace.sh
@@ -919,7 +919,7 @@ install_package() {
 	info "Installing '$1'"
 
 	istrue ${opt_force} && install_args="-DFORCE_PKG_REGISTER"
-	istrue ${opt_batch} && install_args="${_install_args} -DBATCH"
+	istrue ${opt_batch} && install_args="${install_args} -DBATCH"
 
 	cd "$1" || return 1
 	xtry ${PKG_MAKE} ${install_args} reinstall || return 1


### PR DESCRIPTION
Looks like there is a typo in the variable name (underscore in `_install_args`).

```
#pkg_replace --batch zstd
...
[1/1] Deinstalling zstd-1.5.7...
[1/1] Deleting files for zstd-1.5.7: 100%
--->  Installing '/usr/ports/archivers/zstd'
/usr/local/sbin/pkg_replace: _install_args: parameter not set
rmdir: /var/tmp/pkg_replace.LWMAM1: Directory not empty
** Command failed (exit code 1): rmdir /var/tmp/pkg_replace.LWMAM1
** Couldn't remove the working direcotry: /var/tmp/pkg_replace.LWMAM1
```
Note, it does not try to restore the prior version, the package is gone!
